### PR TITLE
Support run levels & php-cs-fixer

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,7 @@ before_script:
 
 script:
   - ./vendor/bin/phpunit --coverage-clover build/logs/clover.xml
+  - ./phpcs.sh --dry-run --diff
 
 after_success:
   - ./vendor/bin/coveralls

--- a/README.md
+++ b/README.md
@@ -36,6 +36,19 @@ NaughtyTestDetector is installable via [Composer](http://getcomposer.org) and sh
                         <string>hello world</string>
                     </element>
                 </array>
+                <!-- Optionally specify levels on which MetricFetcher should be executed -->
+                <!-- Note: values below are the default ones -->
+                <array>
+                    <element key="executeOnTestLevel">
+                        <boolean>false</boolean>
+                    </element>
+                    <element key="executeOnTestSuiteLevel">
+                        <boolean>true</boolean>
+                    </element>                
+                    <element key="executeOnGlobalLevel">
+                        <boolean>false</boolean>
+                    </element>
+                </array>
             </arguments>
         </listener>
     </listeners>

--- a/phpcs.sh
+++ b/phpcs.sh
@@ -1,0 +1,74 @@
+#!/usr/bin/env bash
+
+export PHP_CS_FIXER=~/.composer/vendor/bin/php-cs-fixer
+
+if ! [ -x "$(command -v ${PHP_CS_FIXER})" ]; then
+    echo 'Command `php-cs-fixer` not found. Installing...'
+    composer global require friendsofphp/php-cs-fixer
+fi
+
+${PHP_CS_FIXER} fix  --fixers="\
+    array_element_no_space_before_comma,\
+    array_element_white_space_after_comma,\
+    braces,\
+    concat_with_spaces,\
+    duplicate_semicolon,\
+    elseif,\
+    encoding,\
+    eof_ending,\
+    extra_empty_lines,\
+    function_call_space,\
+    function_declaration,\
+    indentation,\
+    join_function,\
+    line_after_namespace,\
+    linefeed,\
+    list_commas,\
+    lowercase_constants,\
+    lowercase_keywords,\
+    method_argument_space,\
+    multiline_array_trailing_comma,\
+    multiple_use,\
+    new_with_braces,\
+    no_blank_lines_after_class_opening,\
+    no_empty_lines_after_phpdocs,\
+    object_operator,\
+    operators_spaces,\
+    ordered_use,\
+    parenthesis,\
+    php4_constructor,\
+    php_closing_tag,\
+    php_unit_construct,\
+    phpdoc_indent,\
+    phpdoc_no_access,\
+    phpdoc_no_package,\
+    phpdoc_order,\
+    phpdoc_scalar,\
+    phpdoc_separation,\
+    phpdoc_to_comment,\
+    phpdoc_trim,\
+    phpdoc_type_to_var,\
+    phpdoc_types,\
+    phpdoc_var_without_name,\
+    print_to_echo,\
+    remove_leading_slash_use,\
+    remove_lines_between_uses,\
+    return,\
+    short_array_syntax,\
+    short_bool_cast,\
+    short_tag,\
+    single_blank_line_before_namespace,\
+    single_line_after_imports,\
+    single_quote,\
+    spaces_before_semicolon,\
+    standardize_not_equal,\
+    ternary_spaces,\
+    trailing_spaces,\
+    trim_array_spaces,\
+    unalign_double_arrow,\
+    unalign_equals,\
+    unneeded_control_parentheses,\
+    unused_use,\
+    visibility,\
+    whitespacy_lines"\
+    $@ .

--- a/src/PHPUnit/Listeners/NaughtyTestListener.php
+++ b/src/PHPUnit/Listeners/NaughtyTestListener.php
@@ -167,6 +167,7 @@ class NaughtyTestListener extends BaseTestListener
         if ($this->metricFetcher === null) {
             return [];
         }
+
         return $this->metricFetcher->fetchMetrics();
     }
 
@@ -178,6 +179,7 @@ class NaughtyTestListener extends BaseTestListener
     /**
      * @param array $metricsBefore
      * @param array $metricsAfter
+     *
      * @return array
      */
     private function evaluateModifications(array $metricsBefore, array $metricsAfter)

--- a/src/PHPUnit/Listeners/NaughtyTestListener.php
+++ b/src/PHPUnit/Listeners/NaughtyTestListener.php
@@ -3,6 +3,8 @@ namespace PetrKotek\NaughtyTestDetector\PHPUnit\Listeners;
 
 use PetrKotek\NaughtyTestDetector\MetricFetcher;
 use PHPUnit_Framework_BaseTestListener as BaseTestListener;
+use PHPUnit_Framework_Test as Test;
+use PHPUnit_Framework_TestCase as TestCase;
 use PHPUnit_Framework_TestSuite as TestSuite;
 
 /**
@@ -10,24 +12,58 @@ use PHPUnit_Framework_TestSuite as TestSuite;
  */
 class NaughtyTestListener extends BaseTestListener
 {
-    /** @var int[] Key is a metric name, value is a metric value before the run */
-    private $metricsBeforeRun = [];
+    /** @var string Config key enabling execution of MetricFetcher on test-level (bool) */
+    const CONFIG_KEY_LEVEL_TEST = 'executeOnTestLevel';
 
-    /** @var bool Flag indicate if this is the very first executed test suite */
-    private $firstTestSuite = true;
+    /** @var string Config key enabling execution of MetricFetcher on test suite-level (bool) */
+    const CONFIG_KEY_LEVEL_SUITE = 'executeOnTestSuiteLevel';
+
+    /** @var string Config key enabling execution of MetricFetcher before & after running all tests (bool) */
+    const CONFIG_KEY_LEVEL_GLOBAL = 'executeOnGlobalLevel';
+
+    private $defaultOptions = [
+        self::CONFIG_KEY_LEVEL_TEST => false,
+        self::CONFIG_KEY_LEVEL_SUITE => true,
+        self::CONFIG_KEY_LEVEL_GLOBAL => false,
+    ];
+
+    /** @var mixed[] Key is a metric name, value is a metric value before the globals test suite execution */
+    private $metricsBeforeGlobalTestSuite;
+
+    /** @var mixed[] Key is a metric name, value is a metric value before the test suite execution */
+    private $metricsBeforeTestSuite;
+
+    /** @var mixed[] Key is a metric name, value is a metric value before the test execution */
+    private $metricsBeforeTest;
+
+    /**
+     * Counts test suites. Since there is one "overall" test suite encapsulating all test suits, once this counter is 0,
+     * it's over or the beginning.
+     *
+     * @var int
+     */
+    private $testSuiteCounter = 0;
 
     /** @var MetricFetcher|null */
     private $metricFetcher;
 
+    /** @var array */
+    private $flags;
+
     /**
      * @param string $metricFetcherClass
      * @param array $constructorArgs
+     * @param array $options Array with self::CONFIG_KEY_* as keys and value as noted in constant's comment
      */
-    public function __construct($metricFetcherClass = null, array $constructorArgs = [])
-    {
+    public function __construct(
+        $metricFetcherClass = null,
+        array $constructorArgs = [],
+        array $options = []
+    ) {
         if ($metricFetcherClass !== null) {
             $this->metricFetcher = new $metricFetcherClass(...$constructorArgs);
         }
+        $this->flags = array_merge($this->defaultOptions, $options);
     }
 
     /**
@@ -35,12 +71,16 @@ class NaughtyTestListener extends BaseTestListener
      */
     public function startTestSuite(TestSuite $suite)
     {
-        // We need to fetch counts before the very first test suite.
-        // Next test suites will store counts in endTestSuite() method call
-        if ($this->firstTestSuite) {
-            $this->metricsBeforeRun = $this->fetchMetrics();
-            $this->firstTestSuite = false;
+        if ($this->testSuiteCounter === 0 &&
+            ($this->isLevelEnabled(self::CONFIG_KEY_LEVEL_SUITE) || $this->isLevelEnabled(self::CONFIG_KEY_LEVEL_GLOBAL))
+        ) {
+            $currentMetrics = $this->fetchMetrics();
+            $this->metricsBeforeGlobalTestSuite = $currentMetrics;
+            $this->metricsBeforeTestSuite = $currentMetrics;
+            $this->metricsBeforeTest = $currentMetrics;
         }
+
+        $this->testSuiteCounter++;
     }
 
     /**
@@ -48,35 +88,62 @@ class NaughtyTestListener extends BaseTestListener
      */
     public function endTestSuite(TestSuite $suite)
     {
-        $currentMetrics = $this->fetchMetrics();
+        $this->testSuiteCounter--;
+        $currentMetrics = $this->isLevelEnabled(self::CONFIG_KEY_LEVEL_TEST) ? $this->metricsBeforeTest : null;
 
-        $modifications = [];
+        if ($suite->getName() !== '' && $this->isLevelEnabled(self::CONFIG_KEY_LEVEL_SUITE)) {
+            // finished test suite
+            $currentMetrics = $currentMetrics ?: $this->fetchMetrics();
+            $modifications = $this->evaluateModifications($this->metricsBeforeTestSuite, $currentMetrics);
 
-        // evaluate metrics, which we had before the run
-        foreach ($this->metricsBeforeRun as $metric => $previousValue) {
-            $currentValue = array_key_exists($metric, $currentMetrics) ? $currentMetrics[$metric] : null;
-            if ($currentValue !== $previousValue) {
-                $diffString = '';
-                $currentValue = $this->formatValue($currentValue);
-                if (is_numeric($previousValue) && is_numeric($currentValue)) {
-                    $diffNum = $currentValue - $previousValue;
-                    $diffString = sprintf(' (%s%d)', $diffNum > 0 ? '+' : '-', abs($diffNum));
-                }
-                $modifications[$metric] = $this->formatValue($previousValue) . ' -> ' . $this->formatValue($currentValue) . $diffString;
+            if (count($modifications) > 0) {
+                $this->printNaughtyTest('TestSuite ' . $suite->getName(), $modifications);
+            }
+
+            $this->metricsBeforeTestSuite = $currentMetrics;
+        }
+
+        if ($this->testSuiteCounter === 0 && $this->isLevelEnabled(self::CONFIG_KEY_LEVEL_GLOBAL)) {
+            // finished the global test suite
+            $currentMetrics = $currentMetrics ?: $this->fetchMetrics();
+            $modifications = $this->evaluateModifications($this->metricsBeforeGlobalTestSuite, $currentMetrics);
+
+            if (count($modifications) > 0) {
+                $this->printNaughtyTest('Global TestSuite', $modifications);
             }
         }
+    }
 
-        // evaluate metrics, which we didn't have before the run
-        $newMetrics = array_diff_key($currentMetrics, $this->metricsBeforeRun);
-        foreach ($newMetrics as $metric => $currentValue) {
-            $modifications[$metric] = $this->formatValue(null) . ' -> ' . $this->formatValue($currentValue);
+    /**
+     * @param Test $test
+     */
+    public function startTest(Test $test)
+    {
+        if ($this->metricsBeforeTest === null && $this->isLevelEnabled(self::CONFIG_KEY_LEVEL_TEST)) {
+            $this->metricsBeforeTest = $this->fetchMetrics();
         }
+    }
 
-        if (count($modifications) > 0) {
-            $this->printNaughtyTest($suite->getName(), $modifications);
+    /**
+     * @param Test $test
+     * @param float $time
+     */
+    public function endTest(Test $test, $time)
+    {
+        if (!($test instanceof TestCase)) {
+            return;
         }
+        if ($this->isLevelEnabled(self::CONFIG_KEY_LEVEL_TEST)) {
+            $currentMetrics = $this->fetchMetrics();
 
-        $this->metricsBeforeRun = $currentMetrics;
+            $modifications = $this->evaluateModifications($this->metricsBeforeTest, $currentMetrics);
+
+            if (count($modifications) > 0) {
+                $this->printNaughtyTest('Test ' . $test->getName(), $modifications);
+            }
+
+            $this->metricsBeforeTest = $currentMetrics;
+        }
     }
 
     /**
@@ -106,5 +173,42 @@ class NaughtyTestListener extends BaseTestListener
     private function formatValue($value)
     {
         return $value !== null ? $value : 'n/a';
+    }
+
+    /**
+     * @param array $metricsBefore
+     * @param array $metricsAfter
+     * @return array
+     */
+    private function evaluateModifications(array $metricsBefore, array $metricsAfter)
+    {
+        $modifications = [];
+
+        // evaluate metrics, which we had before the run
+        foreach ($metricsBefore as $metric => $previousValue) {
+            $currentValue = array_key_exists($metric, $metricsAfter) ? $metricsAfter[$metric] : null;
+            if ($currentValue !== $previousValue) {
+                $diffString = '';
+                $currentValue = $this->formatValue($currentValue);
+                if (is_numeric($previousValue) && is_numeric($currentValue)) {
+                    $diffNum = $currentValue - $previousValue;
+                    $diffString = sprintf(' (%s%d)', $diffNum > 0 ? '+' : '-', abs($diffNum));
+                }
+                $modifications[$metric] = $this->formatValue($previousValue) . ' -> ' . $this->formatValue($currentValue) . $diffString;
+            }
+        }
+
+        // evaluate metrics, which we didn't have before the run
+        $newMetrics = array_diff_key($metricsAfter, $metricsBefore);
+        foreach ($newMetrics as $metric => $currentValue) {
+            $modifications[$metric] = $this->formatValue(null) . ' -> ' . $this->formatValue($currentValue);
+        }
+
+        return $modifications;
+    }
+
+    private function isLevelEnabled($level)
+    {
+        return array_key_exists($level, $this->flags) && $this->flags[$level];
     }
 }

--- a/tests/PHPUnit/Listeners/NaughtyTestListenerTest.php
+++ b/tests/PHPUnit/Listeners/NaughtyTestListenerTest.php
@@ -3,19 +3,19 @@ namespace PetrKotek\NaughtyTestDetector\Tests\PHPUnit\Listeners;
 
 use PetrKotek\NaughtyTestDetector\PHPUnit\Listeners\NaughtyTestListener;
 use PetrKotek\NaughtyTestDetector\Tests\PHPUnit\Listeners\Dummy;
+use PHPUnit_Framework_MockObject_MockObject as MockObject;
 use PHPUnit_Framework_TestCase as TestCase;
+use PHPUnit_Framework_TestListener as TestListener;
 use PHPUnit_Framework_TestSuite as TestSuite;
 
 class NaughtyTestListenerTest extends TestCase
 {
     public function testNoMetricFetcherConfigured()
     {
-        $testSuite = $this->createTestSuiteMock('DummyTestSuite');
         $testListener = new NaughtyTestListener();
 
         $this->startOutputCapture();
-        $testListener->startTestSuite($testSuite);
-        $testListener->endTestSuite($testSuite);
+        $this->runTestSuites($testListener, [1]);
         $output = $this->finishOutputCapture();
 
         static::assertSame('', $output);
@@ -23,12 +23,10 @@ class NaughtyTestListenerTest extends TestCase
 
     public function testOneTestSuiteNoChange()
     {
-        $testSuite = $this->createTestSuiteMock('DummyTestSuite');
         $testListener = new NaughtyTestListener(Dummy\StableFetcher::class);
 
         $this->startOutputCapture();
-        $testListener->startTestSuite($testSuite);
-        $testListener->endTestSuite($testSuite);
+        $this->runTestSuites($testListener, [1]);
         $output = $this->finishOutputCapture();
 
         static::assertSame('', $output);
@@ -36,32 +34,28 @@ class NaughtyTestListenerTest extends TestCase
 
     public function testOneTestSuiteWithChange()
     {
-        $testSuite = $this->createTestSuiteMock('DummyTestSuite');
         $testListener = new NaughtyTestListener(Dummy\CountingFetcher::class);
 
         $this->startOutputCapture();
-        $testListener->startTestSuite($testSuite);
-        $testListener->endTestSuite($testSuite);
+        $this->runTestSuites($testListener, [1]);
         $output = $this->finishOutputCapture();
 
         $this->assertSameLines([
-            'DummyTestSuite is naughty!',
+            'TestSuite DummyTestSuite1 is naughty!',
             ' - counter: 0 -> 1 (+1)',
         ], $output);
     }
 
     public function testOneTestSuiteWithMultipleChanges()
     {
-        $testSuite = $this->createTestSuiteMock('DummyTestSuite');
         $testListener = new NaughtyTestListener(Dummy\MultiCountingFetcher::class);
 
         $this->startOutputCapture();
-        $testListener->startTestSuite($testSuite);
-        $testListener->endTestSuite($testSuite);
+        $this->runTestSuites($testListener, [1]);
         $output = $this->finishOutputCapture();
 
         $this->assertSameLines([
-            'DummyTestSuite is naughty!',
+            'TestSuite DummyTestSuite1 is naughty!',
             ' - counter1: 0 -> 1 (+1)',
             ' - counter2: 0 -> 2 (+2)',
         ], $output);
@@ -69,16 +63,14 @@ class NaughtyTestListenerTest extends TestCase
 
     public function testOneTestSuiteWithVaryingMetrics()
     {
-        $testSuite = $this->createTestSuiteMock('DummyTestSuite');
         $testListener = new NaughtyTestListener(Dummy\VaryingMetricFetcher::class);
 
         $this->startOutputCapture();
-        $testListener->startTestSuite($testSuite);
-        $testListener->endTestSuite($testSuite);
+        $this->runTestSuites($testListener, [1]);
         $output = $this->finishOutputCapture();
 
         $this->assertSameLines([
-            'DummyTestSuite is naughty!',
+            'TestSuite DummyTestSuite1 is naughty!',
             ' - counter0: 42 -> n/a',
             ' - counter1: n/a -> 42',
         ], $output);
@@ -86,15 +78,10 @@ class NaughtyTestListenerTest extends TestCase
 
     public function testTwoTestSuitesNoChange()
     {
-        $testSuite1 = $this->createTestSuiteMock('DummyTestSuite1');
-        $testSuite2 = $this->createTestSuiteMock('DummyTestSuite2');
         $testListener = new NaughtyTestListener(Dummy\StableFetcher::class);
 
         $this->startOutputCapture();
-        $testListener->startTestSuite($testSuite1);
-        $testListener->endTestSuite($testSuite1);
-        $testListener->startTestSuite($testSuite2);
-        $testListener->endTestSuite($testSuite2);
+        $this->runTestSuites($testListener, [1, 1]);
         $output = $this->finishOutputCapture();
 
         static::assertSame('', $output);
@@ -102,30 +89,141 @@ class NaughtyTestListenerTest extends TestCase
 
     public function testTwoTestSuitesWithChange()
     {
-        $testSuite1 = $this->createTestSuiteMock('DummyTestSuite1');
-        $testSuite2 = $this->createTestSuiteMock('DummyTestSuite2');
-
         $testListener = new NaughtyTestListener(Dummy\CountingFetcher::class);
 
         $this->startOutputCapture();
-        $testListener->startTestSuite($testSuite1);
-        $testListener->endTestSuite($testSuite1);
-        $testListener->startTestSuite($testSuite2);
-        $testListener->endTestSuite($testSuite2);
+        $this->runTestSuites($testListener, [1, 1]);
         $output = $this->finishOutputCapture();
 
         $this->assertSameLines([
-            'DummyTestSuite1 is naughty!',
+            'TestSuite DummyTestSuite1 is naughty!',
             ' - counter: 0 -> 1 (+1)',
             '',
-            'DummyTestSuite2 is naughty!',
+            'TestSuite DummyTestSuite2 is naughty!',
             ' - counter: 1 -> 2 (+1)',
+        ], $output);
+    }
+
+    public function testGlobalTestSuiteLevelOnly()
+    {
+        $testListener = new NaughtyTestListener(Dummy\CountingFetcher::class, [], [
+            NaughtyTestListener::CONFIG_KEY_LEVEL_GLOBAL => true,
+            NaughtyTestListener::CONFIG_KEY_LEVEL_SUITE => false,
+        ]);
+
+        $this->startOutputCapture();
+        $this->runTestSuites($testListener, [2, 1]);
+        $output = $this->finishOutputCapture();
+
+        $this->assertSameLines([
+            'Global TestSuite is naughty!',
+            ' - counter: 0 -> 1 (+1)',
+        ], $output);
+    }
+
+    public function testTestLevelOnly()
+    {
+        $testListener = new NaughtyTestListener(Dummy\CountingFetcher::class, [], [
+            NaughtyTestListener::CONFIG_KEY_LEVEL_TEST => true,
+            NaughtyTestListener::CONFIG_KEY_LEVEL_SUITE => false,
+        ]);
+
+        $this->startOutputCapture();
+        $this->runTestSuites($testListener, [2, 1]);
+        $output = $this->finishOutputCapture();
+
+        $this->assertSameLines([
+            'Test DummyTestSuite1::testFoo1 is naughty!',
+            ' - counter: 0 -> 1 (+1)',
+            '',
+
+            'Test DummyTestSuite1::testFoo2 is naughty!',
+            ' - counter: 1 -> 2 (+1)',
+            '',
+            'Test DummyTestSuite2::testFoo1 is naughty!',
+            ' - counter: 2 -> 3 (+1)',
+        ], $output);
+    }
+
+    public function testTestAndTestSuiteLevel()
+    {
+        $testListener = new NaughtyTestListener(Dummy\CountingFetcher::class, [], [
+            NaughtyTestListener::CONFIG_KEY_LEVEL_SUITE => true,
+            NaughtyTestListener::CONFIG_KEY_LEVEL_TEST => true,
+        ]);
+
+        $this->startOutputCapture();
+        $this->runTestSuites($testListener, [1, 2]);
+        $output = $this->finishOutputCapture();
+
+
+        $this->assertSameLines([
+            'Test DummyTestSuite1::testFoo1 is naughty!',
+            ' - counter: 0 -> 1 (+1)',
+            '',
+            'TestSuite DummyTestSuite1 is naughty!',
+            ' - counter: 0 -> 1 (+1)',
+            '',
+
+            'Test DummyTestSuite2::testFoo1 is naughty!',
+            ' - counter: 1 -> 2 (+1)',
+            '',
+            'Test DummyTestSuite2::testFoo2 is naughty!',
+            ' - counter: 2 -> 3 (+1)',
+            '',
+            'TestSuite DummyTestSuite2 is naughty!',
+            ' - counter: 1 -> 3 (+2)',
+        ], $output);
+    }
+
+    public function testAllLevels()
+    {
+        $testListener = new NaughtyTestListener(Dummy\CountingFetcher::class, [], [
+            NaughtyTestListener::CONFIG_KEY_LEVEL_GLOBAL => true,
+            NaughtyTestListener::CONFIG_KEY_LEVEL_SUITE => true,
+            NaughtyTestListener::CONFIG_KEY_LEVEL_TEST => true,
+        ]);
+
+        $this->startOutputCapture();
+        $this->runTestSuites($testListener, [1, 1]);
+        $output = $this->finishOutputCapture();
+
+
+        $this->assertSameLines([
+            'Test DummyTestSuite1::testFoo1 is naughty!',
+            ' - counter: 0 -> 1 (+1)',
+            '',
+            'TestSuite DummyTestSuite1 is naughty!',
+            ' - counter: 0 -> 1 (+1)',
+            '',
+
+            'Test DummyTestSuite2::testFoo1 is naughty!',
+            ' - counter: 1 -> 2 (+1)',
+            '',
+            'TestSuite DummyTestSuite2 is naughty!',
+            ' - counter: 1 -> 2 (+1)',
+            '',
+            'Global TestSuite is naughty!',
+            ' - counter: 0 -> 2 (+2)',
         ], $output);
     }
 
     private function createTestSuiteMock($name)
     {
         $mock = $this->getMock(TestSuite::class);
+        $mock->expects(static::any())
+            ->method('getName')
+            ->willReturn($name);
+        return $mock;
+    }
+
+    /**
+     * @param string $name
+     * @return MockObject|TestCase
+     */
+    private function createTestCaseMock($name)
+    {
+        $mock = $this->getMock(TestCase::class);
         $mock->expects(static::any())
             ->method('getName')
             ->willReturn($name);
@@ -159,5 +257,35 @@ class NaughtyTestListenerTest extends TestCase
     private function assertSameLines(array $expected, $actual)
     {
         static::assertSame(implode(PHP_EOL, $expected), trim($actual, PHP_EOL));
+    }
+
+    /**
+     * Simulates run of a PHPUnit:
+     *   1. starts "global test suite"
+     *   2. executes all the "test suites"
+     *   3. within the test suites, executes given count tests
+     *
+     * @param TestListener $testListener
+     * @param array $testCounts An array with counts of tests per test suite. E.g. [5, 2, 7] means execute 3 test suites
+     *                          with 5, 2 and 7 tests.
+     */
+    private function runTestSuites(TestListener $testListener, array $testCounts)
+    {
+        $testSuiteRoot = $this->createTestSuiteMock('');
+        $testListener->startTestSuite($testSuiteRoot);
+
+        foreach ($testCounts as $i => $testCount) {
+            $testSuiteName = 'DummyTestSuite' . ($i + 1);
+            $testSuite = $this->createTestSuiteMock($testSuiteName);
+            $testListener->startTestSuite($testSuite);
+            foreach (range(1, $testCount) as $testNumber) {
+                $test = $this->createTestCaseMock($testSuiteName . '::testFoo' . $testNumber);
+                $testListener->startTest($test);
+                $testListener->endTest($test, mt_rand(10, 100));
+            }
+            $testListener->endTestSuite($testSuite);
+        }
+
+        $testListener->endTestSuite($testSuiteRoot);
     }
 }

--- a/tests/PHPUnit/Listeners/NaughtyTestListenerTest.php
+++ b/tests/PHPUnit/Listeners/NaughtyTestListenerTest.php
@@ -2,7 +2,6 @@
 namespace PetrKotek\NaughtyTestDetector\Tests\PHPUnit\Listeners;
 
 use PetrKotek\NaughtyTestDetector\PHPUnit\Listeners\NaughtyTestListener;
-use PetrKotek\NaughtyTestDetector\Tests\PHPUnit\Listeners\Dummy;
 use PHPUnit_Framework_MockObject_MockObject as MockObject;
 use PHPUnit_Framework_TestCase as TestCase;
 use PHPUnit_Framework_TestListener as TestListener;
@@ -156,7 +155,6 @@ class NaughtyTestListenerTest extends TestCase
         $this->runTestSuites($testListener, [1, 2]);
         $output = $this->finishOutputCapture();
 
-
         $this->assertSameLines([
             'Test DummyTestSuite1::testFoo1 is naughty!',
             ' - counter: 0 -> 1 (+1)',
@@ -188,7 +186,6 @@ class NaughtyTestListenerTest extends TestCase
         $this->runTestSuites($testListener, [1, 1]);
         $output = $this->finishOutputCapture();
 
-
         $this->assertSameLines([
             'Test DummyTestSuite1::testFoo1 is naughty!',
             ' - counter: 0 -> 1 (+1)',
@@ -214,11 +211,13 @@ class NaughtyTestListenerTest extends TestCase
         $mock->expects(static::any())
             ->method('getName')
             ->willReturn($name);
+
         return $mock;
     }
 
     /**
      * @param string $name
+     *
      * @return MockObject|TestCase
      */
     private function createTestCaseMock($name)
@@ -227,6 +226,7 @@ class NaughtyTestListenerTest extends TestCase
         $mock->expects(static::any())
             ->method('getName')
             ->willReturn($name);
+
         return $mock;
     }
 


### PR DESCRIPTION
- Support run levels (test-level, testsuite-level, global-level).
- Setup `php-cs-fixer` (use `./phpcs.sh`)
