### PR TITLE
Fix non-object warning

### DIFF
--- a/src/PHPUnit/Listeners/NaughtyTestListener.php
+++ b/src/PHPUnit/Listeners/NaughtyTestListener.php
@@ -205,10 +205,14 @@ class NaughtyTestListener implements TestListener
             try {
                 $encoded = json_encode($value, true);
                 if (json_last_error() !== 0) {
-                    $encoded = sprintf('Object<%s>', get_class($value));
+                    throw new \Exception(json_last_error_msg());
                 }
             } catch (Exception $exception) {
-                $encoded = sprintf('Object<%s>', get_class($value));
+                if (is_object($value)) {
+                    $encoded = sprintf('Object<%s>', get_class($value));
+                } else {
+                    $encoded = gettype($value);
+                }
             }
         }
 


### PR DESCRIPTION
Fix the warning when some value is an array and can't be encoded to JSON for some reasons.