### PR TITLE
extend php version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,8 @@
 language: php
 
 php:
-  - "7.1"
+  - "7.2"
+  - "8.0"
 
 install:
   - composer install --no-interaction

--- a/composer.json
+++ b/composer.json
@@ -17,10 +17,10 @@
         }
     },
     "require": {
-        "php": "^7.1"
+        "php": ">=7.2"
     },
     "require-dev": {
-        "phpunit/phpunit": "^7.0",
+        "phpunit/phpunit": "^8.5",
         "satooshi/php-coveralls": "^1.0"
     }
 }


### PR DESCRIPTION
Change PHP version in composer to `>=7.2`. Also changed `phpunit` to `8.5` because it also has requirements `>=7.2`. This will unblock projects that want to move to new versions of PHP with minimal changes in library.